### PR TITLE
[ID-148] Expose create and delete many messages BBs APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Expose create and delete many messages BBs APIs [#148](https://github.com/rokwire/notifications-building-block/issues/148)
 
 ## [1.13.0] - 2023-02-21
 ### Added

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -18,18 +18,13 @@ import (
 	"errors"
 	"notifications/core/model"
 	"notifications/driven/storage"
-	"time"
 
 	"github.com/rokwire/logging-library-go/v2/logs"
 )
 
-func (app *Application) bbsCreateMessage(orgID string, appID string,
-	sender model.Sender, mTime time.Time, priority int, subject string, body string, data map[string]string,
-	inputRecipients []model.MessageRecipient, recipientsCriteriaList []model.RecipientCriteria,
-	recipientAccountCriteria map[string]interface{}, topic *string, async bool) (*model.Message, error) {
+func (app *Application) bbsCreateMessage(inputMessage model.InputMessage) (*model.Message, error) {
 
-	return app.sharedCreateMessage(orgID, appID, sender, mTime, priority, subject, body, data,
-		inputRecipients, recipientsCriteriaList, recipientAccountCriteria, topic, async)
+	return app.sharedCreateMessage(inputMessage)
 }
 
 func (app *Application) bbsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error {

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -28,43 +28,40 @@ func (app *Application) bbsCreateMessages(inputMessages []model.InputMessage) ([
 }
 
 func (app *Application) bbsDeleteMessages(l *logs.Log, serviceAccountID string, messagesIDs []string) error {
-	// TODO for now
-	messageID := messagesIDs[0]
-
 	//in transaction
 	transaction := func(context storage.TransactionContext) error {
-		//find the message
-		message, err := app.storage.FindMessageWithContext(context, messageID)
+		//find the messages
+		messages, err := app.storage.FindMessagesWithContext(context, messagesIDs)
 		if err != nil {
 			return err
 		}
-		if message == nil {
-			return errors.New("no message for id - " + messageID)
+		if len(messagesIDs) != len(messages) {
+			return errors.New("not found message's")
 		}
+		/*
+			//validate if the service account is the sender of this message
+			valid := app.isSenderValid(serviceAccountID, *message)
+			if !valid {
+				return errors.New("not valid service account id for message - " + messageID)
+			}
 
-		//validate if the service account is the sender of this message
-		valid := app.isSenderValid(serviceAccountID, *message)
-		if !valid {
-			return errors.New("not valid service account id for message - " + messageID)
-		}
+			//delete the message
+			err = app.storage.DeleteMessageWithContext(context, message.OrgID, message.AppID, messageID)
+			if err != nil {
+				return err
+			}
 
-		//delete the message
-		err = app.storage.DeleteMessageWithContext(context, message.OrgID, message.AppID, messageID)
-		if err != nil {
-			return err
-		}
+			//delete the message recipients
+			err = app.storage.DeleteMessagesRecipientsForMessageWithContext(context, messageID)
+			if err != nil {
+				return err
+			}
 
-		//delete the message recipients
-		err = app.storage.DeleteMessagesRecipientsForMessageWithContext(context, messageID)
-		if err != nil {
-			return err
-		}
-
-		//delete the queue data items
-		err = app.storage.DeleteQueueDataForMessageWithContext(context, messageID)
-		if err != nil {
-			return err
-		}
+			//delete the queue data items
+			err = app.storage.DeleteQueueDataForMessageWithContext(context, messageID)
+			if err != nil {
+				return err
+			} */
 
 		return nil
 	}

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -56,18 +56,18 @@ func (app *Application) bbsDeleteMessages(l *logs.Log, serviceAccountID string, 
 		if err != nil {
 			return err
 		}
-		/*
-			//delete the message recipients
-			err = app.storage.DeleteMessagesRecipientsForMessageWithContext(context, messageID)
-			if err != nil {
-				return err
-			}
 
-			//delete the queue data items
-			err = app.storage.DeleteQueueDataForMessageWithContext(context, messageID)
-			if err != nil {
-				return err
-			} */
+		//delete the messages recipients
+		err = app.storage.DeleteMessagesRecipientsForMessagesWithContext(context, messagesIDs)
+		if err != nil {
+			return err
+		}
+
+		//delete the queue data items
+		err = app.storage.DeleteQueueDataForMessagesWithContext(context, messagesIDs)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	}

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -27,7 +27,10 @@ func (app *Application) bbsCreateMessages(inputMessages []model.InputMessage) ([
 	return app.sharedCreateMessages(inputMessages)
 }
 
-func (app *Application) bbsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error {
+func (app *Application) bbsDeleteMessages(l *logs.Log, serviceAccountID string, messagesIDs []string) error {
+	// TODO for now
+	messageID := messagesIDs[0]
+
 	//in transaction
 	transaction := func(context storage.TransactionContext) error {
 		//find the message

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rokwire/logging-library-go/v2/logs"
 )
 
-func (app *Application) bbsCreateMessages(inputMessages []model.InputMessage) (*model.Message, error) {
+func (app *Application) bbsCreateMessages(inputMessages []model.InputMessage) ([]model.Message, error) {
 
 	return app.sharedCreateMessages(inputMessages)
 }

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -22,9 +22,9 @@ import (
 	"github.com/rokwire/logging-library-go/v2/logs"
 )
 
-func (app *Application) bbsCreateMessage(inputMessage model.InputMessage) (*model.Message, error) {
+func (app *Application) bbsCreateMessages(inputMessages []model.InputMessage) (*model.Message, error) {
 
-	return app.sharedCreateMessage(inputMessage)
+	return app.sharedCreateMessages(inputMessages)
 }
 
 func (app *Application) bbsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error {

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -47,13 +47,16 @@ func (app *Application) bbsDeleteMessages(l *logs.Log, serviceAccountID string, 
 			}
 		}
 
+		//delete the message
+		messagesIDs := make([]string, len(messages))
+		for i, m := range messages {
+			messagesIDs[i] = m.ID
+		}
+		err = app.storage.DeleteMessagesWithContext(context, messagesIDs)
+		if err != nil {
+			return err
+		}
 		/*
-			//delete the message
-			err = app.storage.DeleteMessageWithContext(context, message.OrgID, message.AppID, messageID)
-			if err != nil {
-				return err
-			}
-
 			//delete the message recipients
 			err = app.storage.DeleteMessagesRecipientsForMessageWithContext(context, messageID)
 			if err != nil {

--- a/core/app_apis_bbs.go
+++ b/core/app_apis_bbs.go
@@ -38,13 +38,16 @@ func (app *Application) bbsDeleteMessages(l *logs.Log, serviceAccountID string, 
 		if len(messagesIDs) != len(messages) {
 			return errors.New("not found message's")
 		}
-		/*
-			//validate if the service account is the sender of this message
-			valid := app.isSenderValid(serviceAccountID, *message)
-			if !valid {
-				return errors.New("not valid service account id for message - " + messageID)
-			}
 
+		//validate if the service account is the sender of the messages
+		for _, m := range messages {
+			valid := app.isSenderValid(serviceAccountID, m)
+			if !valid {
+				return errors.New("not valid service account id for message - " + m.ID)
+			}
+		}
+
+		/*
 			//delete the message
 			err = app.storage.DeleteMessageWithContext(context, message.OrgID, message.AppID, messageID)
 			if err != nil {

--- a/core/app_apis_services.go
+++ b/core/app_apis_services.go
@@ -153,7 +153,7 @@ func (app *Application) deleteUserMessage(orgID string, appID string, userID str
 }
 
 func (app *Application) deleteMessage(orgID string, appID string, ID string) error {
-	return app.storage.DeleteMessageWithContext(context.Background(), orgID, appID, ID)
+	return app.storage.DeleteMessagesWithContext(context.Background(), []string{ID})
 }
 
 func (app *Application) getAllAppVersions(orgID string, appID string) ([]model.AppVersion, error) {

--- a/core/app_apis_services.go
+++ b/core/app_apis_services.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"notifications/core/model"
 )
@@ -69,8 +70,16 @@ func (app *Application) updateTopic(topic *model.Topic) (*model.Topic, error) {
 }
 
 func (app *Application) createMessage(inputMessage model.InputMessage) (*model.Message, error) {
-	messages := []model.InputMessage{inputMessage}
-	return app.sharedCreateMessages(messages)
+	inputMessages := []model.InputMessage{inputMessage} //only one
+	messages, err := app.sharedCreateMessages(inputMessages)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
+		return nil, errors.New("error on creating message")
+	}
+
+	return &messages[0], nil //return only one
 }
 
 func (app *Application) getMessagesRecipientsDeep(orgID string, appID string, userID *string, read *bool, mute *bool, messageIDs []string, startDateEpoch *int64, endDateEpoch *int64, filterTopic *string, offset *int64, limit *int64, order *string) ([]model.MessageRecipient, error) {

--- a/core/app_apis_services.go
+++ b/core/app_apis_services.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"notifications/core/model"
-	"time"
 )
 
 func (app *Application) getVersion() string {
@@ -69,13 +68,8 @@ func (app *Application) updateTopic(topic *model.Topic) (*model.Topic, error) {
 	return app.storage.UpdateTopic(topic)
 }
 
-func (app *Application) createMessage(orgID string, appID string,
-	sender model.Sender, mTime time.Time, priority int, subject string, body string, data map[string]string,
-	inputRecipients []model.MessageRecipient, recipientsCriteriaList []model.RecipientCriteria,
-	recipientAccountCriteria map[string]interface{}, topic *string, async bool) (*model.Message, error) {
-
-	return app.sharedCreateMessage(orgID, appID, sender, mTime, priority, subject, body, data,
-		inputRecipients, recipientsCriteriaList, recipientAccountCriteria, topic, async)
+func (app *Application) createMessage(inputMessage model.InputMessage) (*model.Message, error) {
+	return app.sharedCreateMessage(inputMessage)
 }
 
 func (app *Application) getMessagesRecipientsDeep(orgID string, appID string, userID *string, read *bool, mute *bool, messageIDs []string, startDateEpoch *int64, endDateEpoch *int64, filterTopic *string, offset *int64, limit *int64, order *string) ([]model.MessageRecipient, error) {

--- a/core/app_apis_services.go
+++ b/core/app_apis_services.go
@@ -69,7 +69,8 @@ func (app *Application) updateTopic(topic *model.Topic) (*model.Topic, error) {
 }
 
 func (app *Application) createMessage(inputMessage model.InputMessage) (*model.Message, error) {
-	return app.sharedCreateMessage(inputMessage)
+	messages := []model.InputMessage{inputMessage}
+	return app.sharedCreateMessages(messages)
 }
 
 func (app *Application) getMessagesRecipientsDeep(orgID string, appID string, userID *string, read *bool, mute *bool, messageIDs []string, startDateEpoch *int64, endDateEpoch *int64, filterTopic *string, offset *int64, limit *int64, order *string) ([]model.MessageRecipient, error) {

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -155,7 +155,7 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 			item.ID = uuid.NewString()
 			item.MessageID = messageID
 			item.Read = false
-			item.DateCreated = now
+			item.DateCreated = &now
 
 			list[i] = item
 		}
@@ -177,7 +177,7 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 		for i, item := range topicUsers {
 			topicRecipients[i] = model.MessageRecipient{
 				OrgID: orgID, AppID: appID, ID: uuid.NewString(), UserID: item.UserID,
-				MessageID: messageID, DateCreated: now,
+				MessageID: messageID, DateCreated: &now,
 			}
 		}
 
@@ -209,7 +209,7 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 		for i, item := range criteriaUsers {
 			criteriaRecipients[i] = model.MessageRecipient{
 				OrgID: orgID, AppID: appID, ID: uuid.NewString(), UserID: item.UserID,
-				MessageID: messageID, DateCreated: now,
+				MessageID: messageID, DateCreated: &now,
 			}
 		}
 
@@ -237,7 +237,7 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 		for _, account := range accounts {
 			messageRecipient := model.MessageRecipient{
 				OrgID: orgID, AppID: appID, ID: uuid.NewString(), UserID: account.ID,
-				MessageID: messageID, DateCreated: now,
+				MessageID: messageID, DateCreated: &now,
 			}
 
 			messageRecipients = append(messageRecipients, messageRecipient)

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -82,6 +82,8 @@ func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) ([
 			notifyQueue = true
 		}
 
+		resultMessages = allMessages
+
 		return nil
 	}
 

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -144,6 +144,7 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 
 	messageRecipients := []model.MessageRecipient{}
 	checkCriteria := true
+	now := time.Now()
 
 	// recipients from message
 	if len(recipients) > 0 {
@@ -154,6 +155,7 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 			item.ID = uuid.NewString()
 			item.MessageID = messageID
 			item.Read = false
+			item.DateCreated = now
 
 			list[i] = item
 		}
@@ -174,8 +176,8 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 		topicRecipients := make([]model.MessageRecipient, len(topicUsers))
 		for i, item := range topicUsers {
 			topicRecipients[i] = model.MessageRecipient{
-				OrgID: orgID, AppID: appID,
-				ID: uuid.NewString(), UserID: item.UserID, MessageID: messageID,
+				OrgID: orgID, AppID: appID, ID: uuid.NewString(), UserID: item.UserID,
+				MessageID: messageID, DateCreated: now,
 			}
 		}
 
@@ -206,8 +208,8 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 		criteriaRecipients := make([]model.MessageRecipient, len(criteriaUsers))
 		for i, item := range criteriaUsers {
 			criteriaRecipients[i] = model.MessageRecipient{
-				OrgID: orgID, AppID: appID,
-				ID: uuid.NewString(), UserID: item.UserID, MessageID: messageID,
+				OrgID: orgID, AppID: appID, ID: uuid.NewString(), UserID: item.UserID,
+				MessageID: messageID, DateCreated: now,
 			}
 		}
 
@@ -234,8 +236,8 @@ func (app *Application) sharedCalculateRecipients(context storage.TransactionCon
 
 		for _, account := range accounts {
 			messageRecipient := model.MessageRecipient{
-				OrgID: orgID, AppID: appID,
-				ID: uuid.NewString(), UserID: account.ID, MessageID: messageID,
+				OrgID: orgID, AppID: appID, ID: uuid.NewString(), UserID: account.ID,
+				MessageID: messageID, DateCreated: now,
 			}
 
 			messageRecipients = append(messageRecipients, messageRecipient)

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -31,7 +31,7 @@ func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) (*
 	var recipients []model.MessageRecipient
 	notifyQueue := false
 
-	//TODO
+	//TODO - TODO
 	im := imMessages[0] //for now
 
 	//in transaction

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -24,12 +24,15 @@ import (
 	"github.com/google/uuid"
 )
 
-func (app *Application) sharedCreateMessage(im model.InputMessage) (*model.Message, error) {
+func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) (*model.Message, error) {
 
 	var err error
 	var persistedMessage *model.Message
 	var recipients []model.MessageRecipient
 	notifyQueue := false
+
+	//TODO
+	im := imMessages[0] //for now
 
 	//in transaction
 	transaction := func(context storage.TransactionContext) error {

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -37,14 +37,17 @@ func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) (*
 	//in transaction
 	transaction := func(context storage.TransactionContext) error {
 
-		//generate message id
-		//TODO - use form input if available
-		messageID := uuid.NewString()
+		//use from input if available
+		messageID := im.ID
+		if messageID == nil {
+			genMessageID := uuid.NewString()
+			messageID = &genMessageID
+		}
 
 		//calculate the recipients
 		recipients, err = app.sharedCalculateRecipients(context, im.OrgID, im.AppID,
 			im.Subject, im.Body, im.InputRecipients, im.RecipientsCriteriaList,
-			im.RecipientAccountCriteria, im.Topic, messageID)
+			im.RecipientAccountCriteria, im.Topic, *messageID)
 		if err != nil {
 			fmt.Printf("error on calculating recipients for a message: %s", err)
 			return err
@@ -54,10 +57,10 @@ func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) (*
 		if im.Data == nil { //we add message id to the data
 			im.Data = map[string]string{}
 		}
-		im.Data["message_id"] = messageID
+		im.Data["message_id"] = *messageID
 		calculatedRecipients := len(recipients)
 		dateCreated := time.Now()
-		message := model.Message{OrgID: im.OrgID, AppID: im.AppID, ID: messageID, Priority: im.Priority, Time: im.Time,
+		message := model.Message{OrgID: im.OrgID, AppID: im.AppID, ID: *messageID, Priority: im.Priority, Time: im.Time,
 			Subject: im.Subject, Sender: im.Sender, Body: im.Body, Data: im.Data, RecipientsCriteriaList: im.RecipientsCriteriaList,
 			Topic: im.Topic, CalculatedRecipientsCount: &calculatedRecipients, DateCreated: &dateCreated}
 

--- a/core/app_apis_shared.go
+++ b/core/app_apis_shared.go
@@ -22,67 +22,57 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rokwire/logging-library-go/v2/errors"
 )
 
-func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) (*model.Message, error) {
+func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) ([]model.Message, error) {
+
+	if len(imMessages) == 0 {
+		return nil, errors.New("no data")
+	}
 
 	var err error
-	var persistedMessage *model.Message
-	var recipients []model.MessageRecipient
+	resultMessages := []model.Message{}
 	notifyQueue := false
-
-	//TODO - TODO
-	im := imMessages[0] //for now
 
 	//in transaction
 	transaction := func(context storage.TransactionContext) error {
 
-		//use from input if available
-		messageID := im.ID
-		if messageID == nil {
-			genMessageID := uuid.NewString()
-			messageID = &genMessageID
+		allMessages := []model.Message{}
+		allRecipients := []model.MessageRecipient{}
+		allQueueItems := []model.QueueItem{}
+
+		//process every message
+		for _, im := range imMessages {
+			message, recipients, err := app.sharedHandleInputMessage(context, im)
+			if err != nil {
+				fmt.Printf("error on handling a message: %s", err)
+				return err
+			}
+			queueItems := app.sharedCreateQueueItems(*message, recipients)
+
+			allMessages = append(allMessages, *message)
+			allRecipients = append(allRecipients, recipients...)
+			allQueueItems = append(allQueueItems, queueItems...)
 		}
 
-		//calculate the recipients
-		recipients, err = app.sharedCalculateRecipients(context, im.OrgID, im.AppID,
-			im.Subject, im.Body, im.InputRecipients, im.RecipientsCriteriaList,
-			im.RecipientAccountCriteria, im.Topic, *messageID)
-		if err != nil {
-			fmt.Printf("error on calculating recipients for a message: %s", err)
-			return err
-		}
-
-		//create message object
-		if im.Data == nil { //we add message id to the data
-			im.Data = map[string]string{}
-		}
-		im.Data["message_id"] = *messageID
-		calculatedRecipients := len(recipients)
-		dateCreated := time.Now()
-		message := model.Message{OrgID: im.OrgID, AppID: im.AppID, ID: *messageID, Priority: im.Priority, Time: im.Time,
-			Subject: im.Subject, Sender: im.Sender, Body: im.Body, Data: im.Data, RecipientsCriteriaList: im.RecipientsCriteriaList,
-			Topic: im.Topic, CalculatedRecipientsCount: &calculatedRecipients, DateCreated: &dateCreated}
-
-		//store the message object
-		persistedMessage, err = app.storage.CreateMessageWithContext(context, message)
+		//store the messages object
+		err = app.storage.InsertMessagesWithContext(context, allMessages)
 		if err != nil {
 			fmt.Printf("error on creating a message: %s", err)
 			return err
 		}
-		log.Printf("message %s has been created", persistedMessage.ID)
 
 		//store recipients
-		err = app.storage.InsertMessagesRecipientsWithContext(context, recipients)
+		err = app.storage.InsertMessagesRecipientsWithContext(context, allRecipients)
 		if err != nil {
 			fmt.Printf("error on inserting recipients: %s", err)
 			return err
 		}
 
-		//create the notifications queue items and store them in the queue
-		queueItems := app.sharedCreateQueueItems(*persistedMessage, recipients)
-		if len(queueItems) > 0 {
-			err = app.storage.InsertQueueDataItemsWithContext(context, queueItems)
+		//store the notifications queue items in the queue
+		if len(allQueueItems) > 0 {
+			err = app.storage.InsertQueueDataItemsWithContext(context, allQueueItems)
 			if err != nil {
 				fmt.Printf("error on inserting queue data items: %s", err)
 				return err
@@ -107,7 +97,38 @@ func (app *Application) sharedCreateMessages(imMessages []model.InputMessage) (*
 		go app.queueLogic.onQueuePush()
 	}
 
-	return persistedMessage, nil
+	return resultMessages, nil
+}
+
+func (app *Application) sharedHandleInputMessage(context storage.TransactionContext, im model.InputMessage) (*model.Message, []model.MessageRecipient, error) {
+	//use from input if available
+	messageID := im.ID
+	if messageID == nil {
+		genMessageID := uuid.NewString()
+		messageID = &genMessageID
+	}
+
+	//calculate the recipients
+	recipients, err := app.sharedCalculateRecipients(context, im.OrgID, im.AppID,
+		im.Subject, im.Body, im.InputRecipients, im.RecipientsCriteriaList,
+		im.RecipientAccountCriteria, im.Topic, *messageID)
+	if err != nil {
+		fmt.Printf("error on calculating recipients for a message: %s", err)
+		return nil, nil, err
+	}
+
+	//create message object
+	if im.Data == nil { //we add message id to the data
+		im.Data = map[string]string{}
+	}
+	im.Data["message_id"] = *messageID
+	calculatedRecipients := len(recipients)
+	dateCreated := time.Now()
+	message := model.Message{OrgID: im.OrgID, AppID: im.AppID, ID: *messageID, Priority: im.Priority, Time: im.Time,
+		Subject: im.Subject, Sender: im.Sender, Body: im.Body, Data: im.Data, RecipientsCriteriaList: im.RecipientsCriteriaList,
+		Topic: im.Topic, CalculatedRecipientsCount: &calculatedRecipients, DateCreated: &dateCreated}
+
+	return &message, recipients, nil
 }
 
 func (app *Application) sharedCreateQueueItems(message model.Message, messageRecipients []model.MessageRecipient) []model.QueueItem {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -152,7 +152,7 @@ func (s *servicesImpl) SendMail(toEmail string, subject string, body string) err
 
 // BBs exposes users related APIs used by the platform building blocks
 type BBs interface {
-	BBsCreateMessages(inputMessages []model.InputMessage) (*model.Message, error)
+	BBsCreateMessages(inputMessages []model.InputMessage) ([]model.Message, error)
 	BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error
 	BBsSendMail(toEmail string, subject string, body string) error
 }
@@ -161,7 +161,7 @@ type bbsImpl struct {
 	app *Application
 }
 
-func (s *bbsImpl) BBsCreateMessages(inputMessages []model.InputMessage) (*model.Message, error) {
+func (s *bbsImpl) BBsCreateMessages(inputMessages []model.InputMessage) ([]model.Message, error) {
 	return s.app.bbsCreateMessages(inputMessages)
 }
 
@@ -205,6 +205,7 @@ type Storage interface {
 	FindMessageWithContext(ctx context.Context, ID string) (*model.Message, error)
 	GetMessage(orgID string, appID string, ID string) (*model.Message, error)
 	CreateMessageWithContext(ctx context.Context, message model.Message) (*model.Message, error)
+	InsertMessagesWithContext(ctx context.Context, messages []model.Message) error
 	UpdateMessage(message *model.Message) (*model.Message, error)
 	DeleteUserMessageWithContext(ctx context.Context, orgID string, appID string, userID string, messageID string) error
 	DeleteMessageWithContext(ctx context.Context, orgID string, appID string, ID string) error

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -202,7 +202,7 @@ type Storage interface {
 	InsertMessagesRecipientsWithContext(ctx context.Context, items []model.MessageRecipient) error
 	DeleteMessagesRecipientsForMessageWithContext(ctx context.Context, messageID string) error
 
-	FindMessageWithContext(ctx context.Context, ID string) (*model.Message, error)
+	FindMessagesWithContext(ctx context.Context, ids []string) ([]model.Message, error)
 	GetMessage(orgID string, appID string, ID string) (*model.Message, error)
 	CreateMessageWithContext(ctx context.Context, message model.Message) (*model.Message, error)
 	InsertMessagesWithContext(ctx context.Context, messages []model.Message) error

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -208,7 +208,7 @@ type Storage interface {
 	InsertMessagesWithContext(ctx context.Context, messages []model.Message) error
 	UpdateMessage(message *model.Message) (*model.Message, error)
 	DeleteUserMessageWithContext(ctx context.Context, orgID string, appID string, userID string, messageID string) error
-	DeleteMessageWithContext(ctx context.Context, orgID string, appID string, ID string) error
+	DeleteMessagesWithContext(ctx context.Context, ids []string) error
 	GetMessagesStats(userID string) (*model.MessagesStats, error)
 	UpdateUnreadMessage(ctx context.Context, orgID string, appID string, ID string, userID string) (*model.Message, error)
 	UpdateAllUserMessagesRead(ctx context.Context, orgID string, appID string, userID string, read bool) error

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -41,10 +41,7 @@ type Services interface {
 	GetMessagesStats(orgID string, appID string, userID string) (*model.MessagesStats, error)
 	GetMessage(orgID string, appID string, ID string) (*model.Message, error)
 	GetUserMessage(orgID string, appID string, ID string, accountID string) (*model.Message, error)
-	CreateMessage(orgID string, appID string,
-		sender model.Sender, time time.Time, priority int, subject string, body string, data map[string]string,
-		inputRecipients []model.MessageRecipient, recipientsCriteriaList []model.RecipientCriteria,
-		recipientAccountCriteria map[string]interface{}, topic *string, async bool) (*model.Message, error)
+	CreateMessage(inputMessage model.InputMessage) (*model.Message, error)
 	UpdateMessage(userID *string, message *model.Message) (*model.Message, error)
 	DeleteUserMessage(orgID string, appID string, userID string, messageID string) error
 	DeleteMessage(orgID string, appID string, ID string) error
@@ -105,12 +102,8 @@ func (s *servicesImpl) GetUserMessage(orgID string, appID string, ID string, acc
 	return s.app.getUserMessage(orgID, appID, ID, accountID)
 }
 
-func (s *servicesImpl) CreateMessage(orgID string, appID string,
-	sender model.Sender, time time.Time, priority int, subject string, body string, data map[string]string,
-	inputRecipients []model.MessageRecipient, recipientsCriteriaList []model.RecipientCriteria,
-	recipientAccountCriteria map[string]interface{}, topic *string, async bool) (*model.Message, error) {
-	return s.app.createMessage(orgID, appID, sender, time, priority, subject, body, data,
-		inputRecipients, recipientsCriteriaList, recipientAccountCriteria, topic, async)
+func (s *servicesImpl) CreateMessage(inputMessage model.InputMessage) (*model.Message, error) {
+	return s.app.createMessage(inputMessage)
 }
 
 func (s *servicesImpl) UpdateMessage(userID *string, message *model.Message) (*model.Message, error) {
@@ -159,10 +152,7 @@ func (s *servicesImpl) SendMail(toEmail string, subject string, body string) err
 
 // BBs exposes users related APIs used by the platform building blocks
 type BBs interface {
-	BBsCreateMessage(orgID string, appID string,
-		sender model.Sender, time time.Time, priority int, subject string, body string, data map[string]string,
-		inputRecipients []model.MessageRecipient, recipientsCriteriaList []model.RecipientCriteria,
-		recipientAccountCriteria map[string]interface{}, topic *string, async bool) (*model.Message, error)
+	BBsCreateMessage(inputMessage model.InputMessage) (*model.Message, error)
 	BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error
 	BBsSendMail(toEmail string, subject string, body string) error
 }
@@ -171,12 +161,8 @@ type bbsImpl struct {
 	app *Application
 }
 
-func (s *bbsImpl) BBsCreateMessage(orgID string, appID string,
-	sender model.Sender, time time.Time, priority int, subject string, body string, data map[string]string,
-	inputRecipients []model.MessageRecipient, recipientsCriteriaList []model.RecipientCriteria,
-	recipientAccountCriteria map[string]interface{}, topic *string, async bool) (*model.Message, error) {
-	return s.app.bbsCreateMessage(orgID, appID, sender, time, priority, subject, body, data,
-		inputRecipients, recipientsCriteriaList, recipientAccountCriteria, topic, async)
+func (s *bbsImpl) BBsCreateMessage(inputMessage model.InputMessage) (*model.Message, error) {
+	return s.app.bbsCreateMessage(inputMessage)
 }
 
 func (s *bbsImpl) BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -152,7 +152,7 @@ func (s *servicesImpl) SendMail(toEmail string, subject string, body string) err
 
 // BBs exposes users related APIs used by the platform building blocks
 type BBs interface {
-	BBsCreateMessage(inputMessage model.InputMessage) (*model.Message, error)
+	BBsCreateMessages(inputMessages []model.InputMessage) (*model.Message, error)
 	BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error
 	BBsSendMail(toEmail string, subject string, body string) error
 }
@@ -161,8 +161,8 @@ type bbsImpl struct {
 	app *Application
 }
 
-func (s *bbsImpl) BBsCreateMessage(inputMessage model.InputMessage) (*model.Message, error) {
-	return s.app.bbsCreateMessage(inputMessage)
+func (s *bbsImpl) BBsCreateMessages(inputMessages []model.InputMessage) (*model.Message, error) {
+	return s.app.bbsCreateMessages(inputMessages)
 }
 
 func (s *bbsImpl) BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -153,7 +153,7 @@ func (s *servicesImpl) SendMail(toEmail string, subject string, body string) err
 // BBs exposes users related APIs used by the platform building blocks
 type BBs interface {
 	BBsCreateMessages(inputMessages []model.InputMessage) ([]model.Message, error)
-	BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error
+	BBsDeleteMessages(l *logs.Log, serviceAccountID string, messagesIDs []string) error
 	BBsSendMail(toEmail string, subject string, body string) error
 }
 
@@ -165,8 +165,8 @@ func (s *bbsImpl) BBsCreateMessages(inputMessages []model.InputMessage) ([]model
 	return s.app.bbsCreateMessages(inputMessages)
 }
 
-func (s *bbsImpl) BBsDeleteMessage(l *logs.Log, serviceAccountID string, messageID string) error {
-	return s.app.bbsDeleteMessage(l, serviceAccountID, messageID)
+func (s *bbsImpl) BBsDeleteMessages(l *logs.Log, serviceAccountID string, messagesIDs []string) error {
+	return s.app.bbsDeleteMessages(l, serviceAccountID, messagesIDs)
 }
 
 func (s *bbsImpl) BBsSendMail(toEmail string, subject string, body string) error {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -200,7 +200,7 @@ type Storage interface {
 	FindMessagesRecipients(orgID string, appID string, messageID string, userID string) ([]model.MessageRecipient, error)
 	FindMessagesRecipientsDeep(orgID string, appID string, userID *string, read *bool, mute *bool, messageIDs []string, startDateEpoch *int64, endDateEpoch *int64, filterTopic *string, offset *int64, limit *int64, order *string) ([]model.MessageRecipient, error)
 	InsertMessagesRecipientsWithContext(ctx context.Context, items []model.MessageRecipient) error
-	DeleteMessagesRecipientsForMessageWithContext(ctx context.Context, messageID string) error
+	DeleteMessagesRecipientsForMessagesWithContext(ctx context.Context, messagesIDs []string) error
 
 	FindMessagesWithContext(ctx context.Context, ids []string) ([]model.Message, error)
 	GetMessage(orgID string, appID string, ID string) (*model.Message, error)
@@ -222,7 +222,7 @@ type Storage interface {
 
 	FindQueueData(time *time.Time, limit int) ([]model.QueueItem, error)
 	DeleteQueueData(ids []string) error
-	DeleteQueueDataForMessageWithContext(ctx context.Context, messageID string) error
+	DeleteQueueDataForMessagesWithContext(ctx context.Context, messagesIDs []string) error
 }
 
 // Firebase is used to wrap all Firebase Messaging API functions

--- a/core/model/message.go
+++ b/core/model/message.go
@@ -18,6 +18,25 @@ import (
 	"time"
 )
 
+// InputMessage represents the data structure needed for creating a message. It is the input data for the core module.
+type InputMessage struct {
+	OrgID string
+	AppID string
+
+	ID *string //use ID if given
+
+	Sender                   Sender
+	Time                     time.Time
+	Priority                 int
+	Subject                  string
+	Body                     string
+	Data                     map[string]string
+	InputRecipients          []MessageRecipient
+	RecipientsCriteriaList   []RecipientCriteria
+	RecipientAccountCriteria map[string]interface{}
+	Topic                    *string
+}
+
 // Message wraps all needed information for the notification. Use either recipients, recipients_criteria or topic in order to address end users
 // @Description wraps all needed information for the notification
 // @ID Message

--- a/core/model/recipient.go
+++ b/core/model/recipient.go
@@ -29,5 +29,5 @@ type MessageRecipient struct {
 
 	Message Message `json:"-" bson:"-"`
 
-	DateCreated time.Time `json:"date_created" bson:"date_created"`
+	DateCreated *time.Time `json:"date_created" bson:"date_created"`
 }

--- a/core/model/recipient.go
+++ b/core/model/recipient.go
@@ -14,6 +14,8 @@
 
 package model
 
+import "time"
+
 // MessageRecipient represent recipient of a message
 type MessageRecipient struct {
 	OrgID string `json:"org_id" bson:"org_id"`
@@ -26,4 +28,6 @@ type MessageRecipient struct {
 	Read      bool   `json:"read" bson:"read"`
 
 	Message Message `json:"-" bson:"-"`
+
+	DateCreated time.Time `json:"date_created" bson:"date_created"`
 }

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -761,17 +761,18 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 		RecipientAccountCriteria  map[string]interface{}    `bson:"recipient_account_criteria"`
 		Topic                     *string                   `bson:"topic"`
 		CalculatedRecipientsCount *int                      `bson:"calculated_recipients_count"`
-		DateCreated               *time.Time                `bson:"date_created"`
+		MessageDateCreated        *time.Time                `bson:"message_date_created"`
 		DateUpdated               *time.Time                `bson:"date_updated"`
 
 		//recipient
-		OrgID     string `bson:"org_id"`
-		AppID     string `bson:"app_id"`
-		ID        string `bson:"_id"`
-		UserID    string `bson:"user_id"`
-		MessageID string `bson:"message_id"`
-		Mute      bool   `bson:"mute"`
-		Read      bool   `bson:"read"`
+		OrgID       string     `bson:"org_id"`
+		AppID       string     `bson:"app_id"`
+		ID          string     `bson:"_id"`
+		UserID      string     `bson:"user_id"`
+		MessageID   string     `bson:"message_id"`
+		Mute        bool       `bson:"mute"`
+		Read        bool       `bson:"read"`
+		DateCreated *time.Time `bson:"date_created"`
 	}
 
 	pipeline := []bson.M{
@@ -783,12 +784,12 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 		}},
 		{"$unwind": "$message"},
 		{"$project": bson.M{"org_id": 1, "app_id": 1, "_id": 1,
-			"user_id": 1, "message_id": 1, "mute": 1, "read": 1,
+			"user_id": 1, "message_id": 1, "mute": 1, "read": 1, "date_created": 1,
 			"priority": "$message.priority", "subject": "$message.subject", "sender": "$message.sender",
 			"body": "$message.body", "data": "$message.data", "recipients": "$message.recipients",
 			"recipients_criteria_list": "$message.recipients_criteria_list", "recipient_account_criteria": "$message.recipient_account_criteria",
 			"topic": "$message.topic", "calculated_recipients_count": "$message.calculated_recipients_count",
-			"date_created": "$message.date_created", "date_updated": "$message.date_updated"}},
+			"message_date_created": "$message.date_created", "date_updated": "$message.date_updated"}},
 		{"$match": bson.M{"org_id": orgID}},
 		{"$match": bson.M{"app_id": appID}},
 	}
@@ -853,12 +854,12 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 			Priority: item.Priority, Subject: item.Subject,
 			Sender: item.Sender, Body: item.Body, Data: item.Data, Recipients: item.Recipients,
 			RecipientsCriteriaList: item.RecipientsCriteriaList, RecipientAccountCriteria: item.RecipientAccountCriteria,
-			Topic: item.Topic, CalculatedRecipientsCount: item.CalculatedRecipientsCount, DateCreated: item.DateCreated,
+			Topic: item.Topic, CalculatedRecipientsCount: item.CalculatedRecipientsCount, DateCreated: item.MessageDateCreated,
 			DateUpdated: item.DateUpdated}
 
 		recipient := model.MessageRecipient{OrgID: item.OrgID, AppID: item.AppID,
 			ID: item.ID, UserID: item.UserID, MessageID: item.MessageID, Mute: item.Mute,
-			Read: item.Read, Message: message}
+			Read: item.Read, Message: message, DateCreated: item.DateCreated}
 		result[i] = recipient
 	}
 

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -953,6 +953,25 @@ func (sa Adapter) CreateMessageWithContext(ctx context.Context, message model.Me
 	return &message, nil
 }
 
+// InsertMessagesWithContext inserts messages.
+func (sa Adapter) InsertMessagesWithContext(ctx context.Context, messages []model.Message) error {
+	data := make([]interface{}, len(messages))
+	for i, p := range messages {
+		data[i] = p
+	}
+
+	res, err := sa.db.messages.InsertManyWithContext(ctx, data, nil)
+	if err != nil {
+		return errors.WrapErrorAction(logutils.ActionInsert, "messagess", nil, err)
+	}
+
+	if len(res.InsertedIDs) != len(messages) {
+		return errors.ErrorAction(logutils.ActionInsert, "messages", &logutils.FieldArgs{"inserted": len(res.InsertedIDs), "expected": len(messages)})
+	}
+
+	return nil
+}
+
 // UpdateMessage updates a message
 func (sa Adapter) UpdateMessage(message *model.Message) (*model.Message, error) {
 	if message != nil {

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -500,7 +500,7 @@ func (sa Adapter) DeleteUserWithID(orgID string, appID string, userID string) er
 
 					if *message.Message.CalculatedRecipientsCount == 1 {
 						//the message has had only one recipient, so we need to remove the message entity too
-						err = sa.DeleteMessageWithContext(sessionContext, orgID, appID, message.ID)
+						err = sa.DeleteMessagesWithContext(sessionContext, []string{message.ID})
 						if err != nil {
 							fmt.Printf("warning: unable to delete message(%s): %s\n", message.ID, err)
 						}
@@ -1026,24 +1026,21 @@ func (sa Adapter) DeleteUserMessageWithContext(ctx context.Context, orgID string
 	return nil
 }
 
-// DeleteMessageWithContext deletes a message by id
-func (sa Adapter) DeleteMessageWithContext(ctx context.Context, orgID string, appID string, ID string) error {
+// DeleteMessagesWithContext deletes messages by ids
+func (sa Adapter) DeleteMessagesWithContext(ctx context.Context, ids []string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	/* why is it here?
 	persistedMessage, err := sa.GetMessage(orgID, appID, ID)
 	if err != nil || persistedMessage == nil {
 		return fmt.Errorf("message with id (%s) not found: %s", ID, err)
-	}
+	} */
 
-	filter := bson.D{
-		primitive.E{Key: "org_id", Value: orgID},
-		primitive.E{Key: "app_id", Value: appID},
-		primitive.E{Key: "_id", Value: ID},
-	}
-	_, err = sa.db.messages.DeleteOneWithContext(ctx, filter, nil)
+	filter := bson.D{primitive.E{Key: "_id", Value: bson.M{"$in": ids}}}
+	_, err := sa.db.messages.DeleteManyWithContext(ctx, filter, nil)
 	if err != nil {
-		fmt.Printf("warning: error while delete message (%s) - %s", ID, err)
+		fmt.Printf("warning: error while delete messages - %s", err)
 		return err
 	}
 

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -888,13 +888,13 @@ func (sa Adapter) InsertMessagesRecipientsWithContext(ctx context.Context, items
 	return nil
 }
 
-// DeleteMessagesRecipientsForMessageWithContext deletes messages recipients for a message
-func (sa Adapter) DeleteMessagesRecipientsForMessageWithContext(ctx context.Context, messageID string) error {
-	filter := bson.D{primitive.E{Key: "message_id", Value: messageID}}
+// DeleteMessagesRecipientsForMessagesWithContext deletes messages recipients for messages
+func (sa Adapter) DeleteMessagesRecipientsForMessagesWithContext(ctx context.Context, messagesIDs []string) error {
+	filter := bson.D{primitive.E{Key: "message_id", Value: bson.M{"$in": messagesIDs}}}
 
 	_, err := sa.db.messagesRecipients.DeleteManyWithContext(ctx, filter, nil)
 	if err != nil {
-		return errors.WrapErrorAction(logutils.ActionDelete, "message recipient", &logutils.FieldArgs{"message_id": messageID}, err)
+		return errors.WrapErrorAction(logutils.ActionDelete, "message recipient", nil, err)
 	}
 	return nil
 }
@@ -1213,13 +1213,13 @@ func (sa *Adapter) DeleteQueueData(ids []string) error {
 	return nil
 }
 
-// DeleteQueueDataForMessageWithContext removes queue data items for a message
-func (sa *Adapter) DeleteQueueDataForMessageWithContext(ctx context.Context, messageID string) error {
-	filter := bson.D{primitive.E{Key: "message_id", Value: messageID}}
+// DeleteQueueDataForMessagesWithContext removes queue data items for messages
+func (sa *Adapter) DeleteQueueDataForMessagesWithContext(ctx context.Context, messagesIDs []string) error {
+	filter := bson.D{primitive.E{Key: "message_id", Value: bson.M{"$in": messagesIDs}}}
 
 	_, err := sa.db.queueData.DeleteManyWithContext(ctx, filter, nil)
 	if err != nil {
-		return errors.WrapErrorAction(logutils.ActionDelete, "queue data", &logutils.FieldArgs{"message_id": messageID}, err)
+		return errors.WrapErrorAction(logutils.ActionDelete, "queue data", nil, err)
 	}
 	return nil
 }

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -899,9 +899,9 @@ func (sa Adapter) DeleteMessagesRecipientsForMessageWithContext(ctx context.Cont
 	return nil
 }
 
-// FindMessageWithContext finds a message by id using context
-func (sa Adapter) FindMessageWithContext(ctx context.Context, ID string) (*model.Message, error) {
-	filter := bson.D{primitive.E{Key: "_id", Value: ID}}
+// FindMessagesWithContext finds messages by ids using context
+func (sa Adapter) FindMessagesWithContext(ctx context.Context, ids []string) ([]model.Message, error) {
+	filter := bson.D{primitive.E{Key: "_id", Value: bson.M{"$in": ids}}}
 
 	var messageArr []model.Message
 	err := sa.db.messages.FindWithContext(ctx, filter, &messageArr, nil)
@@ -909,12 +909,7 @@ func (sa Adapter) FindMessageWithContext(ctx context.Context, ID string) (*model
 		return nil, err
 	}
 
-	if len(messageArr) == 0 {
-		return nil, nil
-	}
-
-	res := messageArr[0]
-	return &res, nil
+	return messageArr, nil
 }
 
 // GetMessage gets a message by id

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -761,18 +761,17 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 		RecipientAccountCriteria  map[string]interface{}    `bson:"recipient_account_criteria"`
 		Topic                     *string                   `bson:"topic"`
 		CalculatedRecipientsCount *int                      `bson:"calculated_recipients_count"`
-		MessageDateCreated        *time.Time                `bson:"message_date_created"`
+		DateCreated               *time.Time                `bson:"date_created"`
 		DateUpdated               *time.Time                `bson:"date_updated"`
 
 		//recipient
-		OrgID       string     `bson:"org_id"`
-		AppID       string     `bson:"app_id"`
-		ID          string     `bson:"_id"`
-		UserID      string     `bson:"user_id"`
-		MessageID   string     `bson:"message_id"`
-		Mute        bool       `bson:"mute"`
-		Read        bool       `bson:"read"`
-		DateCreated *time.Time `bson:"date_created"`
+		OrgID     string `bson:"org_id"`
+		AppID     string `bson:"app_id"`
+		ID        string `bson:"_id"`
+		UserID    string `bson:"user_id"`
+		MessageID string `bson:"message_id"`
+		Mute      bool   `bson:"mute"`
+		Read      bool   `bson:"read"`
 	}
 
 	pipeline := []bson.M{
@@ -784,12 +783,12 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 		}},
 		{"$unwind": "$message"},
 		{"$project": bson.M{"org_id": 1, "app_id": 1, "_id": 1,
-			"user_id": 1, "message_id": 1, "mute": 1, "read": 1, "date_created": 1,
+			"user_id": 1, "message_id": 1, "mute": 1, "read": 1,
 			"priority": "$message.priority", "subject": "$message.subject", "sender": "$message.sender",
 			"body": "$message.body", "data": "$message.data", "recipients": "$message.recipients",
 			"recipients_criteria_list": "$message.recipients_criteria_list", "recipient_account_criteria": "$message.recipient_account_criteria",
 			"topic": "$message.topic", "calculated_recipients_count": "$message.calculated_recipients_count",
-			"message_date_created": "$message.date_created", "date_updated": "$message.date_updated"}},
+			"date_created": "$message.date_created", "date_updated": "$message.date_updated"}},
 		{"$match": bson.M{"org_id": orgID}},
 		{"$match": bson.M{"app_id": appID}},
 	}
@@ -854,12 +853,12 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 			Priority: item.Priority, Subject: item.Subject,
 			Sender: item.Sender, Body: item.Body, Data: item.Data, Recipients: item.Recipients,
 			RecipientsCriteriaList: item.RecipientsCriteriaList, RecipientAccountCriteria: item.RecipientAccountCriteria,
-			Topic: item.Topic, CalculatedRecipientsCount: item.CalculatedRecipientsCount, DateCreated: item.MessageDateCreated,
+			Topic: item.Topic, CalculatedRecipientsCount: item.CalculatedRecipientsCount, DateCreated: item.DateCreated,
 			DateUpdated: item.DateUpdated}
 
 		recipient := model.MessageRecipient{OrgID: item.OrgID, AppID: item.AppID,
 			ID: item.ID, UserID: item.UserID, MessageID: item.MessageID, Mute: item.Mute,
-			Read: item.Read, Message: message, DateCreated: item.DateCreated}
+			Read: item.Read, Message: message}
 		result[i] = recipient
 	}
 

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -117,9 +117,13 @@ func (we Adapter) Start() {
 	// BB APIs
 	bbsRouter := mainRouter.PathPrefix("/bbs").Subrouter()
 	bbsRouter.HandleFunc("/messages", we.wrapFunc(we.bbsApisHandler.SendMessages, we.auth.bbs.Permissions)).Methods("POST")
+	bbsRouter.HandleFunc("/messages", we.wrapFunc(we.bbsApisHandler.DeleteMessages, we.auth.bbs.Permissions)).Methods("DELETE")
+
 	//deprecated
 	bbsRouter.HandleFunc("/message", we.wrapFunc(we.bbsApisHandler.SendMessage, we.auth.bbs.Permissions)).Methods("POST")
 	bbsRouter.HandleFunc("/message/{id}", we.wrapFunc(we.bbsApisHandler.DeleteMessage, we.auth.bbs.Permissions)).Methods("DELETE")
+	//
+
 	bbsRouter.HandleFunc("/mail", we.wrapFunc(we.bbsApisHandler.SendMail, we.auth.bbs.Permissions)).Methods("POST")
 
 	log.Fatal(http.ListenAndServe(":"+we.port, router))

--- a/driver/web/adapter.go
+++ b/driver/web/adapter.go
@@ -116,6 +116,8 @@ func (we Adapter) Start() {
 
 	// BB APIs
 	bbsRouter := mainRouter.PathPrefix("/bbs").Subrouter()
+	bbsRouter.HandleFunc("/messages", we.wrapFunc(we.bbsApisHandler.SendMessages, we.auth.bbs.Permissions)).Methods("POST")
+	//deprecated
 	bbsRouter.HandleFunc("/message", we.wrapFunc(we.bbsApisHandler.SendMessage, we.auth.bbs.Permissions)).Methods("POST")
 	bbsRouter.HandleFunc("/message/{id}", we.wrapFunc(we.bbsApisHandler.DeleteMessage, we.auth.bbs.Permissions)).Methods("DELETE")
 	bbsRouter.HandleFunc("/mail", we.wrapFunc(we.bbsApisHandler.SendMail, we.auth.bbs.Permissions)).Methods("POST")

--- a/driver/web/apis_admin.go
+++ b/driver/web/apis_admin.go
@@ -146,22 +146,22 @@ func (h AdminApisHandler) GetMessages(l *logs.Log, r *http.Request, claims *toke
 // @Security AdminUserAuth
 // @Router /admin/message [post]
 func (h AdminApisHandler) CreateMessage(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
-	var inputMessage Def.SharedReqCreateMessage
-	err := json.NewDecoder(r.Body).Decode(&inputMessage)
+	var inputData Def.SharedReqCreateMessage
+	err := json.NewDecoder(r.Body).Decode(&inputData)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionDecode, logutils.TypeRequestBody, nil, err, http.StatusBadRequest, true)
 	}
 
 	orgID := claims.OrgID
 	appID := claims.AppID
-
-	time, priority, subject, body, inputData, inputRecipients, recipientsCriteria, recipientsAccountCriteria, topic := getMessageData(inputMessage)
-
 	sender := model.Sender{Type: "user", User: &model.CoreAccountRef{UserID: claims.Subject, Name: claims.Name}}
 
-	message, err := h.app.Services.CreateMessage(orgID, appID,
-		sender, time, priority, subject, body, inputData, inputRecipients, recipientsCriteria,
-		recipientsAccountCriteria, topic, false)
+	inputMessage := getMessageData(inputData)
+	inputMessage.OrgID = orgID
+	inputMessage.AppID = appID
+	inputMessage.Sender = sender
+
+	message, err := h.app.Services.CreateMessage(inputMessage)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionCreate, "message", nil, err, http.StatusInternalServerError, true)
 	}

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -156,6 +156,22 @@ func (h BBsAPIsHandler) DeleteMessage(l *logs.Log, r *http.Request, claims *toke
 	return l.HTTPResponseSuccess()
 }
 
+// DeleteMessages deletes messages
+func (h BBsAPIsHandler) DeleteMessages(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
+	/*params := mux.Vars(r)
+	id := params["id"]
+	if len(id) == 0 {
+		return l.HTTPResponseErrorData(logutils.StatusMissing, logutils.TypePathParam, logutils.StringArgs("id"), nil, http.StatusBadRequest, false)
+	}
+
+	err := h.app.BBs.BBsDeleteMessage(l, claims.Subject, id)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionDelete, "message", nil, err, http.StatusInternalServerError, true)
+	} */
+
+	return l.HTTPResponseSuccess()
+}
+
 // sendMailRequestBody mail request body
 type bbsSendMailRequestBody struct {
 	ToMail  string `json:"to_mail"`

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -78,14 +78,17 @@ func (h BBsAPIsHandler) SendMessage(l *logs.Log, r *http.Request, claims *tokena
 	inputMessage.AppID = appID
 	inputMessage.Sender = sender
 
-	messages := []model.InputMessage{inputMessage} //only one message
+	inputMessages := []model.InputMessage{inputMessage} //only one message
 
-	message, err := h.app.BBs.BBsCreateMessages(messages)
+	messages, err := h.app.BBs.BBsCreateMessages(inputMessages)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionSend, "message", nil, err, http.StatusInternalServerError, true)
 	}
+	if len(messages) == 0 {
+		return l.HTTPResponseErrorData(logutils.MessageDataStatus(logutils.StatusError), "message", nil, nil, http.StatusInternalServerError, false)
+	}
 
-	data, err := json.Marshal(message)
+	data, err := json.Marshal(messages[0])
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionMarshal, logutils.TypeResponse, nil, err, http.StatusInternalServerError, true)
 	}

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -148,7 +148,8 @@ func (h BBsAPIsHandler) DeleteMessage(l *logs.Log, r *http.Request, claims *toke
 		return l.HTTPResponseErrorData(logutils.StatusMissing, logutils.TypePathParam, logutils.StringArgs("id"), nil, http.StatusBadRequest, false)
 	}
 
-	err := h.app.BBs.BBsDeleteMessage(l, claims.Subject, id)
+	messagesIDs := []string{id} // only one
+	err := h.app.BBs.BBsDeleteMessages(l, claims.Subject, messagesIDs)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionDelete, "message", nil, err, http.StatusInternalServerError, true)
 	}

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -20,6 +20,7 @@ import (
 	"notifications/core"
 	"notifications/core/model"
 	Def "notifications/driver/web/docs/gen"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/rokwire/core-auth-library-go/v2/tokenauth"
@@ -159,16 +160,19 @@ func (h BBsAPIsHandler) DeleteMessage(l *logs.Log, r *http.Request, claims *toke
 
 // DeleteMessages deletes messages
 func (h BBsAPIsHandler) DeleteMessages(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
-	/*params := mux.Vars(r)
-	id := params["id"]
-	if len(id) == 0 {
-		return l.HTTPResponseErrorData(logutils.StatusMissing, logutils.TypePathParam, logutils.StringArgs("id"), nil, http.StatusBadRequest, false)
+	idsParam := getStringQueryParam(r, "ids")
+	if idsParam == nil {
+		return l.HTTPResponseErrorData(logutils.StatusMissing, logutils.TypePathParam, logutils.StringArgs("ids"), nil, http.StatusBadRequest, false)
+	}
+	ids := strings.Split(*idsParam, ",")
+	if len(ids) == 0 {
+		return l.HTTPResponseErrorData(logutils.StatusInvalid, logutils.TypePathParam, logutils.StringArgs("ids"), nil, http.StatusBadRequest, false)
 	}
 
-	err := h.app.BBs.BBsDeleteMessage(l, claims.Subject, id)
+	err := h.app.BBs.BBsDeleteMessages(l, claims.Subject, ids)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionDelete, "message", nil, err, http.StatusInternalServerError, true)
-	} */
+	}
 
 	return l.HTTPResponseSuccess()
 }

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -78,7 +78,9 @@ func (h BBsAPIsHandler) SendMessage(l *logs.Log, r *http.Request, claims *tokena
 	inputMessage.AppID = appID
 	inputMessage.Sender = sender
 
-	message, err := h.app.BBs.BBsCreateMessage(inputMessage)
+	messages := []model.InputMessage{inputMessage} //only one message
+
+	message, err := h.app.BBs.BBsCreateMessages(messages)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionSend, "message", nil, err, http.StatusInternalServerError, true)
 	}

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -91,6 +91,48 @@ func (h BBsAPIsHandler) SendMessage(l *logs.Log, r *http.Request, claims *tokena
 	return l.HTTPResponseSuccessJSON(data)
 }
 
+// SendMessages sends messages
+func (h BBsAPIsHandler) SendMessages(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
+	/*var bodyData bbsSendMessageRequestBody
+	err := json.NewDecoder(r.Body).Decode(&bodyData)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionDecode, logutils.TypeRequestBody, nil, err, http.StatusBadRequest, true)
+	}
+
+	inputData := bodyData.Message
+
+	if len(inputData.OrgId) == 0 || len(inputData.AppId) == 0 {
+		return l.HTTPResponseErrorData(logutils.StatusInvalid, "org or app id", nil, nil, http.StatusBadRequest, false)
+	}
+
+	if !claims.AppOrg().CanAccessAppOrg(inputData.AppId, inputData.OrgId) {
+		return l.HTTPResponseErrorData(logutils.StatusInvalid, "org or app id", nil, nil, http.StatusForbidden, false)
+	}
+
+	orgID := inputData.OrgId
+	appID := inputData.AppId
+	sender := model.Sender{Type: "system", User: &model.CoreAccountRef{UserID: claims.Subject, Name: claims.Name}}
+
+	inputMessage := getMessageData(inputData)
+	inputMessage.OrgID = orgID
+	inputMessage.AppID = appID
+	inputMessage.Sender = sender
+
+	message, err := h.app.BBs.BBsCreateMessage(inputMessage)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionSend, "message", nil, err, http.StatusInternalServerError, true)
+	}
+
+	data, err := json.Marshal(message)
+	if err != nil {
+		return l.HTTPResponseErrorAction(logutils.ActionMarshal, logutils.TypeResponse, nil, err, http.StatusInternalServerError, true)
+	}
+
+	return l.HTTPResponseSuccessJSON(data) */
+
+	return l.HTTPResponseSuccess()
+}
+
 // DeleteMessage deletes a message
 func (h BBsAPIsHandler) DeleteMessage(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
 	params := mux.Vars(r)

--- a/driver/web/apis_bbs.go
+++ b/driver/web/apis_bbs.go
@@ -95,44 +95,46 @@ func (h BBsAPIsHandler) SendMessage(l *logs.Log, r *http.Request, claims *tokena
 
 // SendMessages sends messages
 func (h BBsAPIsHandler) SendMessages(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
-	/*var bodyData bbsSendMessageRequestBody
+	var bodyData Def.SharedReqCreateMessages
 	err := json.NewDecoder(r.Body).Decode(&bodyData)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionDecode, logutils.TypeRequestBody, nil, err, http.StatusBadRequest, true)
 	}
 
-	inputData := bodyData.Message
-
-	if len(inputData.OrgId) == 0 || len(inputData.AppId) == 0 {
-		return l.HTTPResponseErrorData(logutils.StatusInvalid, "org or app id", nil, nil, http.StatusBadRequest, false)
+	if len(bodyData) == 0 {
+		return l.HTTPResponseErrorData(logutils.StatusInvalid, "no data", nil, nil, http.StatusBadRequest, false)
 	}
 
-	if !claims.AppOrg().CanAccessAppOrg(inputData.AppId, inputData.OrgId) {
-		return l.HTTPResponseErrorData(logutils.StatusInvalid, "org or app id", nil, nil, http.StatusForbidden, false)
+	inputMessages := []model.InputMessage{}
+	//loop through the messages, validate each message and prepare InputMessage obj for every message
+	for _, m := range bodyData {
+		if len(m.OrgId) == 0 || len(m.AppId) == 0 {
+			return l.HTTPResponseErrorData(logutils.StatusInvalid, "org or app id", nil, nil, http.StatusBadRequest, false)
+		}
+
+		if !claims.AppOrg().CanAccessAppOrg(m.AppId, m.OrgId) {
+			return l.HTTPResponseErrorData(logutils.StatusInvalid, "org or app id", nil, nil, http.StatusForbidden, false)
+		}
+
+		inputMessage := getMessageData(m)
+		inputMessage.OrgID = m.OrgId
+		inputMessage.AppID = m.AppId
+		inputMessage.Sender = model.Sender{Type: "system", User: &model.CoreAccountRef{UserID: claims.Subject, Name: claims.Name}}
+
+		inputMessages = append(inputMessages, inputMessage)
 	}
 
-	orgID := inputData.OrgId
-	appID := inputData.AppId
-	sender := model.Sender{Type: "system", User: &model.CoreAccountRef{UserID: claims.Subject, Name: claims.Name}}
-
-	inputMessage := getMessageData(inputData)
-	inputMessage.OrgID = orgID
-	inputMessage.AppID = appID
-	inputMessage.Sender = sender
-
-	message, err := h.app.BBs.BBsCreateMessage(inputMessage)
+	createdMessages, err := h.app.BBs.BBsCreateMessages(inputMessages)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionSend, "message", nil, err, http.StatusInternalServerError, true)
 	}
 
-	data, err := json.Marshal(message)
+	data, err := json.Marshal(createdMessages)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionMarshal, logutils.TypeResponse, nil, err, http.StatusInternalServerError, true)
 	}
 
-	return l.HTTPResponseSuccessJSON(data) */
-
-	return l.HTTPResponseSuccess()
+	return l.HTTPResponseSuccessJSON(data)
 }
 
 // DeleteMessage deletes a message

--- a/driver/web/apis_client.go
+++ b/driver/web/apis_client.go
@@ -246,7 +246,7 @@ func (h ApisHandler) Unsubscribe(l *logs.Log, r *http.Request, claims *tokenauth
 	return l.HTTPResponseSuccess()
 }
 
-//TODO - for now all fields but almost all of them will be removed!
+// TODO - for now all fields but almost all of them will be removed!
 type getUserMessageResponse struct {
 	OrgID                     string                    `json:"org_id"`
 	AppID                     string                    `json:"app_id"`
@@ -471,8 +471,8 @@ func (h ApisHandler) DeleteUserMessages(l *logs.Log, r *http.Request, claims *to
 // @Security UserAuth
 // @Router /message [post]
 func (h ApisHandler) CreateMessage(l *logs.Log, r *http.Request, claims *tokenauth.Claims) logs.HTTPResponse {
-	var inputMessage Def.SharedReqCreateMessage
-	err := json.NewDecoder(r.Body).Decode(&inputMessage)
+	var inputData Def.SharedReqCreateMessage
+	err := json.NewDecoder(r.Body).Decode(&inputData)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionDecode, logutils.TypeRequestBody, nil, err, http.StatusBadRequest, true)
 	}
@@ -480,13 +480,14 @@ func (h ApisHandler) CreateMessage(l *logs.Log, r *http.Request, claims *tokenau
 	orgID := claims.OrgID
 	appID := claims.AppID
 
-	time, priority, subject, body, inputData, inputRecipients, recipientsCriteria, recipientsAccountCriteria, topic := getMessageData(inputMessage)
-
 	sender := model.Sender{Type: "user", User: &model.CoreAccountRef{UserID: claims.Subject, Name: claims.Name}}
 
-	message, err := h.app.Services.CreateMessage(orgID, appID,
-		sender, time, priority, subject, body, inputData, inputRecipients, recipientsCriteria,
-		recipientsAccountCriteria, topic, false)
+	inputMessage := getMessageData(inputData)
+	inputMessage.OrgID = orgID
+	inputMessage.AppID = appID
+	inputMessage.Sender = sender
+
+	message, err := h.app.Services.CreateMessage(inputMessage)
 	if err != nil {
 		return l.HTTPResponseErrorAction(logutils.ActionCreate, "message", nil, err, http.StatusInternalServerError, true)
 	}

--- a/driver/web/bbs_permission_policy.csv
+++ b/driver/web/bbs_permission_policy.csv
@@ -1,3 +1,4 @@
 p, send_message, /notifications/api/bbs/message, (POST), Send message
+p, send_message, /notifications/api/bbs/messages, (POST), Send messages
 p, cancel_message, /notifications/api/bbs/message/*, (DELETE), Delete message
 p, send_email, /notifications/api/bbs/mail, (POST), Send email

--- a/driver/web/bbs_permission_policy.csv
+++ b/driver/web/bbs_permission_policy.csv
@@ -1,4 +1,5 @@
-p, send_message, /notifications/api/bbs/message, (POST), Send message
 p, send_message, /notifications/api/bbs/messages, (POST), Send messages
-p, cancel_message, /notifications/api/bbs/message/*, (DELETE), Delete message
+p, cancel_message, /notifications/api/bbs/messages, (DELETE), Delete messages
+p, send_message, /notifications/api/bbs/message, (POST), Send message - deprecated
+p, cancel_message, /notifications/api/bbs/message/*, (DELETE), Delete message - deprecated
 p, send_email, /notifications/api/bbs/mail, (POST), Send email

--- a/driver/web/common.go
+++ b/driver/web/common.go
@@ -54,9 +54,9 @@ func getBoolQueryParam(r *http.Request, paramName string) *bool {
 	return nil
 }
 
-func getMessageData(inputMessage Def.SharedReqCreateMessage) (time.Time, int, string, string,
+func getMessageData(inputMessage Def.SharedReqCreateMessage) model.InputMessage/* (time.Time, int, string, string,
 	map[string]string, []model.MessageRecipient, []model.RecipientCriteria,
-	map[string]interface{}, *string) {
+	map[string]interface{}, *string) */ {
 
 	mTime := time.Now()
 	if inputMessage.Time != nil {

--- a/driver/web/common.go
+++ b/driver/web/common.go
@@ -54,10 +54,7 @@ func getBoolQueryParam(r *http.Request, paramName string) *bool {
 	return nil
 }
 
-func getMessageData(inputMessage Def.SharedReqCreateMessage) model.InputMessage/* (time.Time, int, string, string,
-	map[string]string, []model.MessageRecipient, []model.RecipientCriteria,
-	map[string]interface{}, *string) */ {
-
+func getMessageData(inputMessage Def.SharedReqCreateMessage) model.InputMessage {
 	mTime := time.Now()
 	if inputMessage.Time != nil {
 		mTime = time.Unix(*inputMessage.Time, 0)
@@ -75,6 +72,7 @@ func getMessageData(inputMessage Def.SharedReqCreateMessage) model.InputMessage/
 	recipientsAccountCriteria := inputMessage.RecipientAccountCriteria
 	topic := inputMessage.Topic
 
-	return mTime, priority, subject, body, inputData, inputRecipients,
-		recipientsCriteria, recipientsAccountCriteria, topic
+	return model.InputMessage{Time: mTime, Priority: priority, Subject: subject,
+		Body: body, Data: inputData, Topic: topic, InputRecipients: inputRecipients,
+		RecipientsCriteriaList: recipientsCriteria, RecipientAccountCriteria: recipientsAccountCriteria}
 }

--- a/driver/web/common.go
+++ b/driver/web/common.go
@@ -72,7 +72,7 @@ func getMessageData(inputMessage Def.SharedReqCreateMessage) model.InputMessage 
 	recipientsAccountCriteria := inputMessage.RecipientAccountCriteria
 	topic := inputMessage.Topic
 
-	return model.InputMessage{Time: mTime, Priority: priority, Subject: subject,
+	return model.InputMessage{ID: inputMessage.Id, Time: mTime, Priority: priority, Subject: subject,
 		Body: body, Data: inputData, Topic: topic, InputRecipients: inputRecipients,
 		RecipientsCriteriaList: recipientsCriteria, RecipientAccountCriteria: recipientsAccountCriteria}
 }

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -1020,6 +1020,7 @@ paths:
       tags:
         - BBs
       summary: Removes a message
+      deprecated: true
       description: |
         Removes а message
 

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -974,9 +974,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/_shared_req_CreateMessage'
+              $ref: '#/components/schemas/_shared_req_CreateMessages'
         required: true
       responses:
         '200':
@@ -1303,6 +1301,10 @@ components:
       properties:
         notifications_disabled:
           type: boolean
+    _shared_req_CreateMessages:
+      type: array
+      items:
+        $ref: '#/components/schemas/_shared_req_CreateMessage'
     _shared_req_CreateMessage:
       required:
         - org_id

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -1318,6 +1318,9 @@ components:
         - recipient_account_criteria
       type: object
       properties:
+        id:
+          type: string
+          description: optional
         org_id:
           type: string
         app_id:

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -43,9 +43,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Message'
         '400':
           description: Bad request
         '401':
@@ -75,9 +73,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Message'
         '400':
           description: Bad request
         '401':
@@ -242,9 +238,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Message'
         '400':
           description: Bad request
         '401':
@@ -855,9 +849,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Message'
         '400':
           description: Bad request
         '401':
@@ -1016,9 +1008,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Message'
         '400':
           description: Bad request
         '401':

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -963,6 +963,7 @@ paths:
       tags:
         - BBs
       summary: Create message
+      deprecated: true
       description: |
         Create message
 

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -958,6 +958,41 @@ paths:
           description: Unauthorized
         '500':
           description: Internal error
+  /api/bbs/messages:
+    post:
+      tags:
+        - BBs
+      summary: Create messages
+      description: |
+        Create messages
+
+        **Auth:** Requires first-party service token with `send_message` permission
+      security:
+        - bearerAuth: []
+      requestBody:
+        description: message body
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/_shared_req_CreateMessage'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Message'
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
   /api/bbs/message:
     post:
       tags:

--- a/driver/web/docs/gen/def.yaml
+++ b/driver/web/docs/gen/def.yaml
@@ -983,6 +983,34 @@ paths:
           description: Unauthorized
         '500':
           description: Internal error
+    delete:
+      tags:
+        - BBs
+      summary: Remove messages
+      description: |
+        Remove messages
+
+        **Auth:** Requires first-party service token with `cancel_message` permission
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: ids
+          in: query
+          description: ids of the messages for deletion separated with comma
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal error
   /api/bbs/message:
     post:
       tags:

--- a/driver/web/docs/gen/gen_types.go
+++ b/driver/web/docs/gen/gen_types.go
@@ -115,9 +115,12 @@ type ClientReqUser struct {
 
 // SharedReqCreateMessage defines model for _shared_req_CreateMessage.
 type SharedReqCreateMessage struct {
-	AppId                    string                                         `json:"app_id"`
-	Body                     string                                         `json:"body"`
-	Data                     map[string]interface{}                         `json:"data"`
+	AppId string                 `json:"app_id"`
+	Body  string                 `json:"body"`
+	Data  map[string]interface{} `json:"data"`
+
+	// optional
+	Id                       *string                                        `json:"id,omitempty"`
 	OrgId                    string                                         `json:"org_id"`
 	Priority                 int                                            `json:"priority"`
 	RecipientAccountCriteria map[string]interface{}                         `json:"recipient_account_criteria"`
@@ -139,6 +142,9 @@ type SharedReqCreateMessageInputRecipientCriteria struct {
 	AppPlatform *string `json:"app_platform,omitempty"`
 	AppVersion  *string `json:"app_version,omitempty"`
 }
+
+// SharedReqCreateMessages defines model for _shared_req_CreateMessages.
+type SharedReqCreateMessages = []SharedReqCreateMessage
 
 // PostApiAdminMessageJSONBody defines parameters for PostApiAdminMessage.
 type PostApiAdminMessageJSONBody = SharedReqCreateMessage
@@ -175,6 +181,9 @@ type PostApiBbsMailJSONBody = ClientReqMail
 
 // PostApiBbsMessageJSONBody defines parameters for PostApiBbsMessage.
 type PostApiBbsMessageJSONBody = ClientReqMessageV2
+
+// PostApiBbsMessagesJSONBody defines parameters for PostApiBbsMessages.
+type PostApiBbsMessagesJSONBody = SharedReqCreateMessages
 
 // PostApiIntMailJSONBody defines parameters for PostApiIntMail.
 type PostApiIntMailJSONBody = ClientReqToken
@@ -268,6 +277,9 @@ type PostApiBbsMailJSONRequestBody = PostApiBbsMailJSONBody
 
 // PostApiBbsMessageJSONRequestBody defines body for PostApiBbsMessage for application/json ContentType.
 type PostApiBbsMessageJSONRequestBody = PostApiBbsMessageJSONBody
+
+// PostApiBbsMessagesJSONRequestBody defines body for PostApiBbsMessages for application/json ContentType.
+type PostApiBbsMessagesJSONRequestBody = PostApiBbsMessagesJSONBody
 
 // PostApiIntMailJSONRequestBody defines body for PostApiIntMail for application/json ContentType.
 type PostApiIntMailJSONRequestBody = PostApiIntMailJSONBody

--- a/driver/web/docs/index.yaml
+++ b/driver/web/docs/index.yaml
@@ -69,6 +69,8 @@ paths:
     $ref: "./resources/admin/message/messages-id.yaml"   
 
   #BBs
+  /api/bbs/messages:
+    $ref: "./resources/bbs/messages.yaml"
   /api/bbs/message:
     $ref: "./resources/bbs/message.yaml"
   /api/bbs/{id}:

--- a/driver/web/docs/resources/admin/message/message.yaml
+++ b/driver/web/docs/resources/admin/message/message.yaml
@@ -19,9 +19,7 @@ post:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../../../schemas/application/Message.yaml"
+            $ref: "../../../schemas/application/Message.yaml"
     400:
       description: Bad request
     401:

--- a/driver/web/docs/resources/bbs/message-id.yaml
+++ b/driver/web/docs/resources/bbs/message-id.yaml
@@ -2,6 +2,7 @@ delete:
   tags:
   - BBs
   summary: Removes a message
+  deprecated: true
   description: |
     Removes а message
 

--- a/driver/web/docs/resources/bbs/message.yaml
+++ b/driver/web/docs/resources/bbs/message.yaml
@@ -22,9 +22,7 @@ post:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../../schemas/application/Message.yaml"
+            $ref: "../../schemas/application/Message.yaml"
     400:
       description: Bad request
     401:

--- a/driver/web/docs/resources/bbs/message.yaml
+++ b/driver/web/docs/resources/bbs/message.yaml
@@ -2,6 +2,7 @@ post:
   tags:
   - BBs
   summary: Create message
+  deprecated: true
   description: |
     Create message
 

--- a/driver/web/docs/resources/bbs/messages.yaml
+++ b/driver/web/docs/resources/bbs/messages.yaml
@@ -1,0 +1,34 @@
+post:
+  tags:
+  - BBs
+  summary: Create messages
+  description: |
+    Create messages
+
+    **Auth:** Requires first-party service token with `send_message` permission
+  security:
+    - bearerAuth: []
+  requestBody:
+    description: message body
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: "../../schemas/apis/shared/requests/create-message/Request.yaml" 
+    required: true    
+  responses:
+    200:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "../../schemas/application/Message.yaml"
+    400:
+      description: Bad request
+    401:
+      description: Unauthorized
+    500:
+      description: Internal error  

--- a/driver/web/docs/resources/bbs/messages.yaml
+++ b/driver/web/docs/resources/bbs/messages.yaml
@@ -29,4 +29,32 @@ post:
     401:
       description: Unauthorized
     500:
+      description: Internal error
+delete:
+  tags:
+  - BBs
+  summary: Remove messages
+  description: |
+    Remove messages
+
+    **Auth:** Requires first-party service token with `cancel_message` permission
+  security:
+    - bearerAuth: []
+  parameters:
+    - name: ids
+      in: query
+      description: ids of the messages for deletion separated with comma
+      required: true
+      style: simple
+      explode: false
+      schema:
+        type: string      
+  responses:
+    200:
+      description: Success
+    400:
+      description: Bad request
+    401:
+      description: Unauthorized
+    500:
       description: Internal error  

--- a/driver/web/docs/resources/bbs/messages.yaml
+++ b/driver/web/docs/resources/bbs/messages.yaml
@@ -13,9 +13,7 @@ post:
     content:
       application/json:
         schema:
-          type: array
-          items:
-            $ref: "../../schemas/apis/shared/requests/create-message/Request.yaml" 
+          $ref: "../../schemas/apis/shared/requests/create-messages/Request.yaml" 
     required: true    
   responses:
     200:

--- a/driver/web/docs/resources/client/message/message.yaml
+++ b/driver/web/docs/resources/client/message/message.yaml
@@ -21,9 +21,7 @@ post:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../../../schemas/application/Message.yaml"
+            $ref: "../../../schemas/application/Message.yaml"
     400:
       description: Bad request
     401:

--- a/driver/web/docs/resources/internal/message.yaml
+++ b/driver/web/docs/resources/internal/message.yaml
@@ -20,9 +20,7 @@ post:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../../schemas/application/Message.yaml"
+            $ref: "../../schemas/application/Message.yaml"
     400:
       description: Bad request
     401:

--- a/driver/web/docs/resources/internal/v2/message.yaml
+++ b/driver/web/docs/resources/internal/v2/message.yaml
@@ -20,8 +20,6 @@ post:
       content:
         application/json:
           schema:
-            type: array
-            items:
               $ref: "../../../schemas/application/Message.yaml"
     400:
       description: Bad request

--- a/driver/web/docs/schemas/apis/shared/requests/create-message/Request.yaml
+++ b/driver/web/docs/schemas/apis/shared/requests/create-message/Request.yaml
@@ -10,6 +10,9 @@ required:
   - recipient_account_criteria
 type: object
 properties:
+  id:
+    type: string
+    description: optional
   org_id:
     type: string
   app_id:

--- a/driver/web/docs/schemas/apis/shared/requests/create-messages/Request.yaml
+++ b/driver/web/docs/schemas/apis/shared/requests/create-messages/Request.yaml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: "../create-message/Request.yaml"

--- a/driver/web/docs/schemas/index.yaml
+++ b/driver/web/docs/schemas/index.yaml
@@ -43,6 +43,8 @@ _client_req_user:
 ## SHARED requests and responses
 
 ### requests
+_shared_req_CreateMessages:
+  $ref: "./apis/shared/requests/create-messages/Request.yaml"
 _shared_req_CreateMessage:
   $ref: "./apis/shared/requests/create-message/Request.yaml"
 _shared_req_CreateMessage_InputMessageRecipient:


### PR DESCRIPTION
## Description

Resolves #148 

Hi @mdryankov @shurwit , here are the highlights of this PR:

- The two BBs APIs for creating and deleting a message are extended to accept many messages instead of one.
- The old APIs are marked as deprecated as the new ones cover their case too.
- In additon when a BB creates a messages it could pass the message id. In case the message id is omitted then it is generated in the Notification BB as it was. This is why the consumers of these APIs must know which message for which reminder for example(in the context of Calendar BB) corresponds etc.
- added date created field in the messages_collection items data
- we have to be carefull when creates many messages at once and when we send topic or other criteria which analyze every message for the recipients on the backend side. If the recipients are passed by the client then we can handle thousands of messages. BTW, in our cases we expect the consumer of the create messages API to send the recipients too but I mention it in case another case appers to have this in mind. I think we are ok now with this implementation.

Let me know if any issues. Thanks!