### PR TITLE
[#168] Use message.time field as a primary delivery time indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use message.time field as a primary delivery time indicator [#168](https://github.com/rokwire/notifications-building-block/issues/168)
 
 ## [1.17.0] - 2023-09-19
 ### Changed

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -850,18 +850,18 @@ func (sa Adapter) FindMessagesRecipientsDeep(orgID string, appID string, userID 
 	if startDateEpoch != nil {
 		seconds := *startDateEpoch / 1000
 		timeValue := time.Unix(seconds, 0)
-		pipeline = append(pipeline, bson.M{"$match": bson.M{"date_created": bson.D{primitive.E{Key: "$gte", Value: &timeValue}}}})
+		pipeline = append(pipeline, bson.M{"$match": bson.M{"time": bson.D{primitive.E{Key: "$gte", Value: &timeValue}}}})
 	}
 	if endDateEpoch != nil {
 		seconds := *endDateEpoch / 1000
 		timeValue := time.Unix(seconds, 0)
-		pipeline = append(pipeline, bson.M{"$match": bson.M{"date_created": bson.D{primitive.E{Key: "$lte", Value: &timeValue}}}})
+		pipeline = append(pipeline, bson.M{"$match": bson.M{"time": bson.D{primitive.E{Key: "$lte", Value: &timeValue}}}})
 	}
 
 	if order != nil && *order == "asc" {
-		pipeline = append(pipeline, bson.M{"$sort": bson.M{"date_created": 1}})
+		pipeline = append(pipeline, bson.M{"$sort": bson.M{"time": 1}})
 	} else {
-		pipeline = append(pipeline, bson.M{"$sort": bson.M{"date_created": -1}})
+		pipeline = append(pipeline, bson.M{"$sort": bson.M{"time": -1}})
 	}
 
 	if limit != nil {

--- a/driven/storage/database.go
+++ b/driven/storage/database.go
@@ -211,6 +211,16 @@ func (m *database) applyMessagesChecks(messages *collectionWrapper) error {
 		}
 	}
 
+	if indexMapping["time_1"] == nil {
+		err := messages.AddIndex(
+			bson.D{
+				primitive.E{Key: "time", Value: 1},
+			}, false)
+		if err != nil {
+			return err
+		}
+	}
+
 	//add sender type index
 	err = messages.AddIndex(bson.D{primitive.E{Key: "sender.type", Value: 1}}, false)
 	if err != nil {


### PR DESCRIPTION
## Description

**Resolves #168**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)