### PR TITLE
[#190] Scheduled notifications calculate recipients immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Scheduled notifications calculate recipients immediately [#190](https://github.com/rokwire/notifications-building-block/issues/190)
 
 ## [1.21.1] - 2024-09-06
 ### Fixed

--- a/core/app.go
+++ b/core/app.go
@@ -78,17 +78,16 @@ func (app *Application) Start() {
 func NewApplication(version string, build string, storage Storage, firebase Firebase, mailer *mailer.Adapter, logger *logs.Logger, core *core.Adapter) *Application {
 
 	timerDone := make(chan bool)
-	queueLogic := queueLogic{logger: logger, storage: storage, firebase: firebase, timerDone: timerDone}
-
 	deleteDataLogic := deleteDataLogic{logger: *logger, coreAdapter: core, storage: storage}
 
 	application := Application{version: version, build: build, storage: storage, firebase: firebase,
-		mailer: mailer, logger: logger, core: core, queueLogic: queueLogic, deleteDataLogic: deleteDataLogic}
+		mailer: mailer, logger: logger, core: core, deleteDataLogic: deleteDataLogic}
 
 	//add the drivers ports/interfaces
 	application.Services = &servicesImpl{app: &application}
 	application.Admin = &adminImpl{app: &application}
 	application.BBs = &bbsImpl{app: &application}
+	application.queueLogic = queueLogic{app: &application, logger: logger, storage: storage, firebase: firebase, timerDone: timerDone, airship: airship}
 
 	return &application
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -236,6 +236,7 @@ type Storage interface {
 	CreateMessageWithContext(ctx context.Context, message model.Message) (*model.Message, error)
 	InsertMessagesWithContext(ctx context.Context, messages []model.Message) error
 	UpdateMessage(message *model.Message) (*model.Message, error)
+	UpdateMessageRecipientCount(ctx context.Context, messageID string, recipientCount int) error
 	DeleteUserMessageWithContext(ctx context.Context, orgID string, appID string, userID string, messageID string) error
 	DeleteMessagesWithContext(ctx context.Context, ids []string) error
 	GetMessagesStats(userID string) (*model.MessagesStats, error)

--- a/core/model/queue.go
+++ b/core/model/queue.go
@@ -44,4 +44,6 @@ type QueueItem struct {
 	//when to send
 	Time     time.Time `bson:"time"`
 	Priority int       `bson:"priority"`
+
+	CalculateRecipients bool `bson:"calculate_recipients"`
 }

--- a/driven/storage/adapter.go
+++ b/driven/storage/adapter.go
@@ -1116,6 +1116,28 @@ func (sa Adapter) UpdateMessage(message *model.Message) (*model.Message, error) 
 	return message, nil
 }
 
+// UpdateMessageRecipientCount updates a message recipient count
+func (sa Adapter) UpdateMessageRecipientCount(ctx context.Context, messageID string, recipientCount int) error {
+	filter := bson.D{
+		primitive.E{Key: "_id", Value: messageID},
+	}
+
+	update := bson.D{
+		primitive.E{Key: "$set", Value: bson.D{
+			primitive.E{Key: "calculated_recipients_count", Value: recipientCount},
+			primitive.E{Key: "date_updated", Value: time.Now().UTC()},
+		}},
+	}
+
+	_, err := sa.db.messages.UpdateOneWithContext(ctx, filter, update, nil)
+	if err != nil {
+		fmt.Printf("warning: error updating message recipient count (%s) - %s", messageID, err)
+		return err
+	}
+
+	return nil
+}
+
 // DeleteUserMessageWithContext removes the desired user from the recipients list
 func (sa Adapter) DeleteUserMessageWithContext(ctx context.Context, orgID string, appID string, userID string, messageID string) error {
 	if ctx == nil {


### PR DESCRIPTION
## Description
_Please provide a summary of the pull request and the issue it resolves. Please add necessary details, context, dependencies, explanation of when review is needed (see next section), etc._

Hi @petyos, we ran into this issue when attempting to use the scheduled notifications for one of our customers so I thought I would open a PR on the main repo too. At a high level I am trying to delay calculating the list of recipients for a scheduled notification until it is time to send out the notification rather than right when it is first scheduled. 

To do this, I created a new type of queue item that does not contain recipient details but has a flag instead telling the queue to compute the topic/criteria recipients for the notification when the queue item is processed. It will then insert all of the normal queue items and recipient data and retrigger the queue.

No rush as I have already merged these changes into our fork, but let me know if you have any questions or see any issues when you get a chance. Thanks!

**Resolves #190**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md).
- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)